### PR TITLE
docs: available-endpoints-new

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -77,7 +77,13 @@ export default defineConfig({
                                     {text: 'Rendered HTML', link: 'api/available-endpoints/rendered-html.md'},
                                 ],
                             },
-
+                            {
+                                text: 'Available API Endpoints (new)',
+                                items: [
+                                    {text: 'Shots (Screenshots and PDFs)', link: 'api/available-endpoints-new/shots.md'},
+                                    {text: 'Rendered HTML', link: 'api/available-endpoints-new/rendered-html.md'},
+                                ],
+                            },
                         ],
                     },
                     {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,0 +1,14 @@
+import DefaultTheme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+
+import { theme, useTheme } from 'vitepress-theme-openapi'
+import 'vitepress-theme-openapi/dist/style.css'
+
+export default {
+    ...DefaultTheme,
+    async enhanceApp({app, router, siteData}) {
+        useTheme().setShowBaseURL(true)
+
+        theme.enhanceApp({ app })
+    }
+} satisfies Theme

--- a/guide/api/available-endpoints-new/rendered-html.md
+++ b/guide/api/available-endpoints-new/rendered-html.md
@@ -1,0 +1,75 @@
+---
+aside: false
+description: Learn how to get the rendered HTML of a URL or of your provide HTML snippet.
+---
+
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import spec from '../../../public/openapi.json'
+
+const { isDark } = useData()
+</script>
+
+<OAOperation :spec="spec" operationId="renderedHtml" :isDark="isDark">
+
+<template #description>
+
+The `/api/v1/renderd-html` API endpoints allows you to generate rendered HTML of a given URL or HTML snippet. You can find a detailed list of all available parameters in the [API reference](/reference/#tag/html).
+
+## Create Rendered HTML from URL
+
+The most basic payload to create a rendered HTML of a URL looks like this.
+
+```json
+{
+    "url": "https://example.com"
+}
+```
+
+The resulting JSON response will contain the rendered HTML. The meta section contains information about your current usage and limits.
+
+```json
+{
+  "data": {
+    "rendered_html": "<html><head></head><body><h1>Hello World</h1></body></html>"
+  },
+  "meta": {
+    "request_id": null,
+    "usage_limit": {
+      "limit": 10000,
+      "usage": 15,
+      "remaining": 9985,
+      "resets": "2024-07-01T00:00:00+00:00"
+    }
+  }
+}
+```
+
+> [!TIP]
+> You can also use the `/api/v1/rendered-html` API to get the rendered HTML of a URL. This can be useful if you want to extract the rendered HTML of a website for further processing. For example, if you need to extract specific information that uses JavaScript to render the content.
+
+## Create Rendered HTML from HTML
+
+If you want to create a rendered HTML from a given HTML snippet, you can use the following payload.
+
+```json
+{
+    "html": "<html><head></head><body><h1>Hello World</h1></body></html>"
+}
+```
+
+---
+
+As mentioned, these are just a few examples of how you can use the `/api/v1/rendered-html` API. For a full list of available parameters and responses, please refer to the [API reference](/reference/#tag/html).
+
+> [!NOTE]
+> The `/api/v1/rendered-html` and `/api/v1/shots` API endpoints are very similar. The main difference is that the `/api/v1/rendered-html` API returns the rendered HTML of a given URL or HTML snippet, while the `/api/v1/shots` API returns a screenshot or PDF of a given URL or HTML snippet.
+> Many of the parameters are the same, so you can use the same payload for both APIs. Note that some parameters like `file_type` are only available in the `/api/v1/shots` API.
+
+You can also try out different parameters in our [playground](https://3.screeenly.com/playground). The playground will also build up the API payload for you, so you can easily copy and paste it into your application.
+
+</template>
+
+</OAOperation>
+
+

--- a/guide/api/available-endpoints-new/shots.md
+++ b/guide/api/available-endpoints-new/shots.md
@@ -1,0 +1,92 @@
+---
+aside: false
+description: >-
+  A "Shot" represents the request to generate a screenshot or PDF of a given URL
+  or HTML snippet.
+---
+
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import spec from '../../../public/openapi.json'
+
+const { isDark } = useData()
+</script>
+
+<OAOperation :spec="spec" operationId="createShot" :isDark="isDark">
+
+<template #description>
+
+The `/api/v1/shots` API endpoints allows you to generate screenshots or PDFs of a given URL or HTML snippet. You can find a detailed list of all available parameters in the [API reference](/reference/#tag/shots).
+
+## Create a screenshot from URL
+
+The most basic payload to create a screenshot of a URL looks like this.
+
+```json
+{
+    "url": "https://en.wikipedia.org/wiki/Special:Random"
+}
+```
+
+The resulting JSON response will contain a URL to download the screenshot or PDF, as well as the expiration date of the generated file. The meta section contains information about your current usage and limits.
+
+```json
+{
+    "data": {
+        "url": "https://en.wikipedia.org/wiki/Special:Random",
+        "expires_at": "2024-06-28T19:20:50+00:00",
+        "screenshot_url": "https://3.screeenly.com/storage/153449/3e23f899-ba17-44ac-a089-48382db7fc7c.jpg"
+    },
+    "meta": {
+        "request_id": null,
+        "usage_limit": {
+            "limit": 1000,
+            "usage": 15,
+            "remaining": 985,
+            "resets": "2024-07-01T00:00:00+00:00"
+        }
+    }
+}
+```
+
+## Create a screenshot from HTML
+
+If you want to create a screenshot from a given HTML snippet, you can use the following payload.
+
+```json
+{
+    "html": "<html><head></head><body><h1>Hello World</h1></body></html>"
+}
+```
+
+## Create a PDF from a URL
+
+To create a PDF from a given URL, you can use the following payload.
+
+```json
+{
+    "url": "https://en.wikipedia.org/wiki/Special:Random",
+    "file_type": "pdf"
+}
+```
+
+## Create a PDF from HTML
+
+To create a PDF from a given HTML snippet, you can use the following payload.
+
+```json
+{
+    "html": "<html><head></head><body><h1>Hello World</h1></body></html>",
+    "file_type": "pdf"
+}
+```
+
+---
+
+As mentioned, these are just a few examples of how you can use the `/api/v1/shots` API. For a full list of available parameters and responses, please refer to the [API reference](/reference/#tag/shots).
+
+You can also try out different parameters in our [playground](https://3.screeenly.com/playground). The playground will also build up the API payload for you, so you can easily copy and paste it into your application.
+
+</template>
+
+</OAOperation>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "screeenly-docs",
+  "name": "screenly-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,8 @@
         "@scalar/api-reference": "^1.24.39"
       },
       "devDependencies": {
-        "vitepress": "^1.3.0"
+        "vitepress": "^1.3.0",
+        "vitepress-theme-openapi": "^0.0.3-alpha.33"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3078,6 +3079,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.0.tgz",
+      "integrity": "sha512-jFI8IQw4hczaL4ALINxqLEXQbWcNjoSkloa4IaufXCJr6QawJyw7tuRysRsrE8w2p/4gGaxKIt/hX3qz/IbD1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "2.0.0"
+      },
+      "funding": {
+        "url": "https://joebell.co.uk"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
@@ -4422,6 +4436,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "peer": true
     },
+    "node_modules/lucide-vue-next": {
+      "version": "0.411.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.411.0.tgz",
+      "integrity": "sha512-fqShZsIt3HT9eHrvb4uGMpmxD7gtMXs9C4aVDy3A2RsDFShIJ+VJhEhKL4PdWW2+HLaH2ivn4Vo7wbTmfYbEWg==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -5750,9 +5774,10 @@
       "peer": true
     },
     "node_modules/radix-vue": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.0.tgz",
-      "integrity": "sha512-Ds1GpB6IBhSyFePWyxDhnqA7Ymgmcxah3t5qWxamftqX/zFRkkf5RaRxzuGB8QgdbP6Q/t7scIdMEcndhFc+Tg==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/radix-vue/-/radix-vue-1.9.6.tgz",
+      "integrity": "sha512-legrn9jHbEpbJS4QYrA0VmIafj1bmc4MSVzN55WZatGiXMJg3oFrQL5QxpiURJciS+OlATbKA2KAGkMuuLA0LA==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.7",
         "@floating-ui/vue": "^1.1.0",
@@ -6457,6 +6482,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
     "node_modules/telejson": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
@@ -6853,6 +6888,35 @@
         "postcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitepress-theme-openapi": {
+      "version": "0.0.3-alpha.33",
+      "resolved": "https://registry.npmjs.org/vitepress-theme-openapi/-/vitepress-theme-openapi-0.0.3-alpha.33.tgz",
+      "integrity": "sha512-kk8vjMY+hZmNCB+uG54R/+Ll94FTePSlfzJXd4r2itjvWqkOL+1ZduS6VPKHCpMFVTvsITYyitVm0pO9xLLVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "^10.11.0",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
+        "lucide-vue-next": "^0.411.0",
+        "radix-vue": "^1.9.1",
+        "tailwind-merge": "^2.4.0",
+        "tailwindcss-animate": "^1.0.7"
+      },
+      "peerDependencies": {
+        "vue": "^3.4.29"
+      }
+    },
+    "node_modules/vitepress-theme-openapi/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
-    "vitepress": "^1.3.0"
+    "vitepress": "^1.3.0",
+    "vitepress-theme-openapi": "^0.0.3-alpha.33"
   },
   "scripts": {
     "docs:dev": "vitepress dev",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,801 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "screeenly API",
+    "description": "The screeenly API allows you to create screenshots, PDFs and HTML from URLs or HTML code.",
+    "termsOfService": "https://3.screeenly.com/terms",
+    "contact": {
+      "name": "Support",
+      "email": "support@screeenly.com"
+    },
+    "version": "3.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://3.screeenly.com/api",
+      "description": "Production Server"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Shots",
+      "description": "Create screenshots or PDFs from URLs or HTML code."
+    },
+    {
+      "name": "HTML",
+      "description": "Get rendered HTML from URLs or HTML code."
+    }
+  ],
+  "paths": {
+    "/v1/shots": {
+      "post": {
+        "summary": "Shots (Screenshots and PDFs)",
+        "description": "Create a new screenshot or PDF from the given URL or the given HTML source code.",
+        "operationId": "createShot",
+        "tags": [
+          "Shots"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BrowsershotRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Response when the screenshot or PDF was created successfully.",
+            "headers": {
+              "X-Usage-Limit": {
+                "$ref": "#/components/headers/X-Usage-Limit"
+              },
+              "X-Usage-Usage": {
+                "$ref": "#/components/headers/X-Usage-Usage"
+              },
+              "X-Usage-Remaining": {
+                "$ref": "#/components/headers/X-Usage-Remaining"
+              },
+              "X-Ratelimit-Limit": {
+                "$ref": "#/components/headers/X-Ratelimit-Limit"
+              },
+              "X-Ratelimit-Remaining": {
+                "$ref": "#/components/headers/X-Ratelimit-Remaining"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowsershotResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "403": {
+            "$ref": "#/components/responses/AuthorizationException"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationException"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyAttemptsException"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerException"
+          }
+        }
+      }
+    },
+    "/v1/rendered-html": {
+      "post": {
+        "summary": "Rendered HTML",
+        "description": "Return the rendered HTML for the given URL or the given HTML code.",
+        "operationId": "renderedHtml",
+        "tags": [
+          "HTML"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HtmlBrowsershotRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Response when the HTML of the given URL or HTML code was rendered successfully.",
+            "headers": {
+              "X-Usage-Limit": {
+                "$ref": "#/components/headers/X-Usage-Limit"
+              },
+              "X-Usage-Usage": {
+                "$ref": "#/components/headers/X-Usage-Usage"
+              },
+              "X-Usage-Remaining": {
+                "$ref": "#/components/headers/X-Usage-Remaining"
+              },
+              "X-Ratelimit-Limit": {
+                "$ref": "#/components/headers/X-Ratelimit-Limit"
+              },
+              "X-Ratelimit-Remaining": {
+                "$ref": "#/components/headers/X-Ratelimit-Remaining"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HtmlBrowsershotResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/AuthenticationException"
+          },
+          "403": {
+            "$ref": "#/components/responses/AuthorizationException"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationException"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyAttemptsException"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerException"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "headers": {
+      "X-Usage-Limit": {
+        "description": "The usage limit of the user",
+        "schema": {
+          "type": "integer",
+          "example": 1000
+        }
+      },
+      "X-Usage-Usage": {
+        "description": "The usage of the user",
+        "schema": {
+          "type": "integer",
+          "example": 15
+        }
+      },
+      "X-Usage-Remaining": {
+        "description": "The remaining usage of the user",
+        "schema": {
+          "type": "integer",
+          "example": 985
+        }
+      },
+      "X-Ratelimit-Limit": {
+        "description": "The maximum number of request the user can make in a minute.",
+        "schema": {
+          "type": "integer",
+          "example": 30
+        }
+      },
+      "X-Ratelimit-Remaining": {
+        "description": "The remaining number of request the user can make in a given minute.",
+        "schema": {
+          "type": "integer",
+          "example": 15
+        }
+      }
+    },
+    "responses": {
+      "AuthenticationException": {
+        "description": "Response when the user is not authenticated",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Unauthenticated."
+                }
+              }
+            }
+          }
+        }
+      },
+      "AuthorizationException": {
+        "description": "Response when the user is not authorized to access the resource or perform the action.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Access denied. Your trial has expired and you did not subscribe to a plan. Subscribe to a plan here: https://3.screeenly.com/billing/subscriptions."
+                }
+              }
+            }
+          }
+        }
+      },
+      "TooManyAttemptsException": {
+        "description": "Response when the user has reached the rate limit.",
+        "headers": {
+          "X-Usage-Limit": {
+            "$ref": "#/components/headers/X-Usage-Limit"
+          },
+          "X-Usage-Usage": {
+            "$ref": "#/components/headers/X-Usage-Usage"
+          },
+          "X-Usage-Remaining": {
+            "$ref": "#/components/headers/X-Usage-Remaining"
+          },
+          "X-Ratelimit-Limit": {
+            "$ref": "#/components/headers/X-Ratelimit-Limit"
+          },
+          "X-Ratelimit-Remaining": {
+            "$ref": "#/components/headers/X-Ratelimit-Remaining"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Too Many Attempts."
+                }
+              }
+            }
+          }
+        }
+      },
+      "ValidationException": {
+        "description": "Response when the given data was invalid.",
+        "headers": {
+          "X-Ratelimit-Limit": {
+            "$ref": "#/components/headers/X-Ratelimit-Limit"
+          },
+          "X-Ratelimit-Remaining": {
+            "$ref": "#/components/headers/X-Ratelimit-Remaining"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "The field is required. (and 1 more error)"
+                },
+                "errors": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "example": "The {{key}} field is required."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ServerException": {
+        "description": "Response when the server encountered an error.",
+        "headers": {
+          "X-Usage-Limit": {
+            "$ref": "#/components/headers/X-Usage-Limit"
+          },
+          "X-Usage-Usage": {
+            "$ref": "#/components/headers/X-Usage-Usage"
+          },
+          "X-Usage-Remaining": {
+            "$ref": "#/components/headers/X-Usage-Remaining"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Server Error."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "BrowsershotRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "https://www.google.com",
+            "description": "The URL must be accessible to screeenly servers"
+          },
+          "html": {
+            "type": "string",
+            "description": "Required, if URL is not set"
+          },
+          "file_type": {
+            "type": "string",
+            "default": "png",
+            "enum": [
+              "jpg",
+              "png",
+              "webp",
+              "pdf"
+            ]
+          },
+          "window_width": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "window_height": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "timeout": {
+            "type": "integer",
+            "default": 10
+          },
+          "delay": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 30000,
+            "default": 0,
+            "description": "Delay in milliseconds before the browser is capturing the screenshot"
+          },
+          "paper_width": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100000
+          },
+          "paper_height": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100000
+          },
+          "paper_format": {
+            "type": "string",
+            "enum": [
+              "A0",
+              "A1",
+              "A2",
+              "A3",
+              "A4",
+              "A5",
+              "A6",
+              "Letter",
+              "Legal",
+              "Tabloid",
+              "Ledger"
+            ]
+          },
+          "paper_margins_top": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 250
+          },
+          "paper_margins_right": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 250
+          },
+          "paper_margins_bottom": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 250
+          },
+          "paper_margins_left": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 250
+          },
+          "paper_orientation": {
+            "type": "string",
+            "enum": [
+              "landscape",
+              "portrait"
+            ],
+            "default": "portrait"
+          },
+          "pdf_show_background": {
+            "type": "boolean",
+            "default": false
+          },
+          "selector": {
+            "type": "string",
+            "example": "#app",
+            "description": "CSS Selector"
+          },
+          "full_page": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates if the entire height of the website should be captured in the screenshot"
+          },
+          "clip_x": {
+            "type": "integer",
+            "description": "The position on the x-axis where the clipping should start"
+          },
+          "clip_y": {
+            "type": "integer",
+            "description": "The position on the y-axis where the clipping should start"
+          },
+          "clip_width": {
+            "type": "integer",
+            "description": "The width of the clip in pixels"
+          },
+          "clip_height": {
+            "type": "integer",
+            "description": "The height of the clip in pixels"
+          },
+          "device_scale_factor": {
+            "type": "integer",
+            "default": 1,
+            "enum": [
+              1,
+              2,
+              3
+            ],
+            "description": "Set the pixel density to generate the screenshot"
+          },
+          "hide_background": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to ignore the website's background when capturing a screenshot"
+          },
+          "transparent_background": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to turn the default background color (white) to transparent."
+          },
+          "show_browser_header_and_footer": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to show the header and footer generated by the browser when generating a PDF."
+          },
+          "header_html": {
+            "type": "string",
+            "description": "HTML to be shown in the browsers header when generating a PDF. Check out [Cookbook](/guide/cookbook/print-headers-and-footers-in-pdfs) for examples.",
+            "example": "<span class=\"date\"></span><span class=\"title\"></span>"
+          },
+          "footer_html": {
+            "type": "string",
+            "description": "HTML to be shown in the browsers footer when generating a PDF. Check out [Cookbook](/guide/cookbook/print-headers-and-footers-in-pdfs) for examples.",
+            "example": "<span class=\"pageNumber\"></span><span class=\"totalPages\"></span>"
+          },
+          "dismiss_dialogs": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to automatically close popups, alerts or confirmation dialogs generated through JavaScript"
+          },
+          "disable_javascript": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to disable JavaScript in the browser."
+          },
+          "wait_until_network_idle_strict": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to allow up to 2 network connections in the 500ms period. This setting is useful, if the website regularly pings and endpoint with XHR."
+          },
+          "disable_web_security": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to disable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) checks in the browser"
+          },
+          "browser_language": {
+            "type": "string",
+            "default": "en-GB",
+            "description": "Must be a valid ISO 639-1 language code."
+          },
+          "css_media_type": {
+            "type": "string",
+            "enum": [
+              "screen",
+              "print"
+            ],
+            "default": "screen"
+          },
+          "ignore_https_errors": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to ignore errors related to HTTPS/SSL certificates"
+          },
+          "http_headers": {
+            "type": "array",
+            "description": "Array of HTTP headers passed to the browser",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "example": "X-My-Header"
+                },
+                "value": {
+                  "type": "string",
+                  "example": "My Value"
+                }
+              }
+            }
+          },
+          "cookies": {
+            "type": "array",
+            "description": "Array of cookies passed to the browser",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "example": "my_cookie"
+                },
+                "value": {
+                  "type": "string",
+                  "example": "my_value"
+                },
+                "domain": {
+                  "type": "string",
+                  "example": "example.com"
+                }
+              }
+            }
+          },
+          "basic_authentication_username": {
+            "type": "string",
+            "description": "The username which should be used for the Basic Authentication"
+          },
+          "basic_authentication_password": {
+            "type": "string",
+            "description": "The password which should be used for the Basic Authentication"
+          }
+        }
+      },
+      "HtmlBrowsershotRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "https://www.google.com",
+            "description": "The URL must be accessible to screeenly servers"
+          },
+          "html": {
+            "type": "string",
+            "description": "Required, if URL is not set"
+          },
+          "window_width": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "window_height": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "timeout": {
+            "type": "integer",
+            "default": 10
+          },
+          "delay": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 30000,
+            "default": 0,
+            "description": "Delay in milliseconds before the browser is capturing the screenshot"
+          },
+          "dismiss_dialogs": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to automatically close popups, alerts or confirmation dialogs generated through JavaScript"
+          },
+          "disable_javascript": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to disable JavaScript in the browser."
+          },
+          "wait_until_network_idle_strict": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to allow up to 2 network connections in the 500ms period. This setting is useful, if the website regularly pings and endpoint with XHR."
+          },
+          "disable_web_security": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to disable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) checks in the browser"
+          },
+          "browser_language": {
+            "type": "string",
+            "default": "en-GB",
+            "description": "Must be a valid ISO 639-1 language code."
+          },
+          "ignore_https_errors": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set to true, to ignore errors related to HTTPS/SSL certificates"
+          },
+          "http_headers": {
+            "type": "array",
+            "description": "Array of HTTP headers passed to the browser",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "example": "X-My-Header"
+                },
+                "value": {
+                  "type": "string",
+                  "example": "My Value"
+                }
+              }
+            }
+          },
+          "cookies": {
+            "type": "array",
+            "description": "Array of cookies passed to the browser",
+            "items": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "example": "my_cookie"
+                },
+                "value": {
+                  "type": "string",
+                  "example": "my_value"
+                },
+                "domain": {
+                  "type": "string",
+                  "example": "example.com"
+                }
+              }
+            }
+          },
+          "basic_authentication_username": {
+            "type": "string",
+            "description": "The username which should be used for the Basic Authentication"
+          },
+          "basic_authentication_password": {
+            "type": "string",
+            "description": "The password which should be used for the Basic Authentication"
+          }
+        }
+      },
+      "BrowsershotResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "example": "https://example.com"
+              },
+              "expires_at": {
+                "type": "integer",
+                "example": 1920
+              },
+              "shot_url": {
+                "type": "string",
+                "example": "https://3.screeenly.com/storage/149032/0c8532c6-38da-4389-a038-5e73e2c42304.jpg"
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "request_id": {
+                "type": "string",
+                "example": null
+              },
+              "usage_limit": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "integer",
+                    "example": 1000
+                  },
+                  "usage": {
+                    "type": "integer",
+                    "example": 15
+                  },
+                  "remaining": {
+                    "type": "integer",
+                    "example": 985
+                  },
+                  "resets": {
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00.000000Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "HtmlBrowsershotResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "rendered_html": {
+                "type": "string",
+                "example": "<html><head></head><body><h1>Hello World</h1></body></html>"
+              }
+            }
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "request_id": {
+                "type": "string",
+                "example": null
+              },
+              "usage_limit": {
+                "type": "object",
+                "properties": {
+                  "limit": {
+                    "type": "integer",
+                    "example": 1000
+                  },
+                  "usage": {
+                    "type": "integer",
+                    "example": 15
+                  },
+                  "remaining": {
+                    "type": "integer",
+                    "example": 985
+                  },
+                  "resets": {
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00.000000Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds new pages to docs under `/guide/api/available-endpoints-new/`, with `vitepress-theme-openapi` integration.

![Peek 2024-10-01 22-38](https://github.com/user-attachments/assets/f7b5538d-ab2f-4359-953b-fe5df775aee6)

This is just an example and can be customized as needed. It could also be a single page containing all operations.